### PR TITLE
Font weights fixed

### DIFF
--- a/src/sass/support/_utilities.scss
+++ b/src/sass/support/_utilities.scss
@@ -79,8 +79,8 @@ Markup:
 .fs-large            - Larger than the default font size
 .fw-light            - Changes the type to be 300 weight
 .fw-normal           - Changes the type to be 400 weight
-.fw-semibold         - Changes the type to be 500 weight
-.fw-bold             - Changes the type to be 600 weight
+.fw-semibold         - Changes the type to be 600 weight
+.fw-bold             - Changes the type to be 700 weight
 
 Styleguide 4.1
 
@@ -108,9 +108,9 @@ Styleguide 4.1
 }
 
 .fw-semibold{
-  font-weight: 500;
+  font-weight: 600;
 }
 
 .fw-bold{
-  font-weight: 600;
+  font-weight: 700;
 }


### PR DESCRIPTION
Bold is identical to 700, in most cases 600 will work the same but fill fail in some specific cases. Semibold is 600, medium weight is 500.

Source - https://www.w3.org/TR/css-fonts-3/#font-weight-numeric-values