### PR TITLE
remove dd text indent

### DIFF
--- a/src/sass/support/_base.scss
+++ b/src/sass/support/_base.scss
@@ -173,9 +173,6 @@ ul ul{
 dt{
   font-style: italic;
 }
-dd{
-  text-indent: 2rem;
-}
 
 blockquote{
   margin: 0 0 2.4rem 1.2rem;

--- a/src/sass/support/_base.scss
+++ b/src/sass/support/_base.scss
@@ -173,6 +173,9 @@ ul ul{
 dt{
   font-style: italic;
 }
+dd{
+  padding-left: 2rem;
+}
 
 blockquote{
   margin: 0 0 2.4rem 1.2rem;


### PR DESCRIPTION
removes the text indent on `dd`, which causes very unsightly visual effect when the definition description is multiline (see example screenshot below)

before:
> ![cute-dd-current](https://cloud.githubusercontent.com/assets/895831/17022921/a3df9e7c-4f48-11e6-9062-e7d023113bf4.png)

after:
> ![cute-dd-fix](https://cloud.githubusercontent.com/assets/895831/17022941/bb2ba4e0-4f48-11e6-9056-645453c74a0b.png)

alternatively, suggest changing from `text-indent` to `padding-left`, which would then move all `dd` content to the right, not just the beginning of each line.

alternative:
> ![cute-dd-alt](https://cloud.githubusercontent.com/assets/895831/17022972/dccdc0a6-4f48-11e6-8a98-a343120af9ce.png)
