### PR TITLE
explicitly reintroduce underline on .btn--link

### DIFF
--- a/src/sass/components/_buttons.scss
+++ b/src/sass/components/_buttons.scss
@@ -36,7 +36,6 @@ Styleguide 2.0
   &:link,
   &:visited{
     color: $white;
-    text-decoration: none;
   }
 
   &:focus,
@@ -81,6 +80,7 @@ Styleguide 2.0
 
   &:link{
     color: $link;
+    text-decoration: underline;
   }
 
   &:visited{


### PR DESCRIPTION
closes https://github.com/cutestrap/cutestrap/issues/25