### PR TITLE
reintroduce underline on .btn--link

### DIFF
--- a/src/sass/components/_buttons.scss
+++ b/src/sass/components/_buttons.scss
@@ -25,6 +25,7 @@ Styleguide 2.0
   height: 4.8rem;
   line-height: 4.8rem;
   max-width: 100%;
+  text-decoration: none;
   transition-property: background-color;
   transition-duration: 200ms;
   margin: 0 auto;
@@ -36,7 +37,6 @@ Styleguide 2.0
   &:link,
   &:visited{
     color: $white;
-    text-decoration: none;
   }
 
   &:focus,


### PR DESCRIPTION
as `.btn:link` is more specific than `.btn--link`, the `text-decoration: none` there currently overrides the intended `text-decoration: underline`. moving the style to `.btn` fixes this, allowing for `<button class="btn--link">...</button>` and `<a href="..." class="btn btn--link">...</a>` to look like actual large links (with underline)

closes https://github.com/cutestrap/cutestrap/issues/25