### PR TITLE
The AMP HTML friendly: Do not use the `!important` qualifier #44

### DIFF
--- a/src/sass/support/_base.scss
+++ b/src/sass/support/_base.scss
@@ -283,5 +283,5 @@ textarea:-webkit-autofill,
 select:-webkit-autofill {
   color: $gray1;
   -webkit-text-fill-color: $gray1;
-  -webkit-box-shadow: 0 0 0px 1000px white inset !important;
+  -webkit-box-shadow: 0 0 0px 1000px white inset;
 }


### PR DESCRIPTION
https://github.com/cutestrap/cutestrap/issues/44

Can not use the `!important` qualifier in the [AMP HTML](https://www.ampproject.org/) site.

https://www.ampproject.org/docs/reference/spec.html#important
> Usage of the `!important` qualifier is not allowed. This is a necessary requirement to enable AMP to enforce its element sizing invariants.

https://github.com/cutestrap/cutestrap/blob/d9985d1/src/sass/support/_base.scss#L286